### PR TITLE
Added limit to explode function for ability call fastfield for tv with dots

### DIFF
--- a/core/components/fastfield/model/fastfield/fastfield.php
+++ b/core/components/fastfield/model/fastfield/fastfield.php
@@ -27,7 +27,7 @@ class modResourceFieldTag extends modFieldTag {
             if (isset($options['content']) && !empty($options['content'])) {
                 $this->_content = $options['content'];
             } else {
-                $tag = explode('.', $this->get('name'));
+                $tag = explode('.', $this->get('name'), 3);
                 $tagLength = count($tag);
                 if (is_numeric($tag[0])) {
                     /** @var xPDOCache $fastFieldCache */


### PR DESCRIPTION
I used write tvs names with dots aka [[*header.desc]] o [[+tv.header.desc]]

When I wrote [[#1.tv.header.desc]], fastField didn't work. I added limit to explode function for limiting chunks of tag for processing. 
