### PR TITLE
Move to MODX 3

### DIFF
--- a/core/components/fastfield/bootstrap.php
+++ b/core/components/fastfield/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @var \MODX\Revolution\modX $this
+ *
+ * @see \MODX\Revolution\modX::_initNamespaces()
+ */
+if ($this->getOption('modParser.class') !== 'fastFieldParser') {
+    return;
+}
+
+require_once __DIR__ . '/model/fastfield/fastfieldparser.class.php';

--- a/core/components/fastfield/model/fastfield/fastfield.php
+++ b/core/components/fastfield/model/fastfield/fastfield.php
@@ -1,5 +1,9 @@
 <?php
 
+use MODX\Revolution\modFieldTag;
+use MODX\Revolution\modX;
+use MODX\Revolution\modResource;
+
 class modResourceFieldTag extends modFieldTag {
 
     /**

--- a/core/components/fastfield/model/fastfield/fastfieldparser.class.php
+++ b/core/components/fastfield/model/fastfield/fastfieldparser.class.php
@@ -1,5 +1,7 @@
 <?php
-    require_once MODX_CORE_PATH . '/model/modx/modparser.class.php';
+
+    use MODX\Revolution\modParser;
+    use xPDO\xPDO;
 
     class fastFieldParser extends modParser {
 


### PR DESCRIPTION
Those changes are required for MODX 3, however this will break support for MODX 2.x.

Furthermore a new system setting `modParser.class` is required with the value `fastFieldParser`, so MODX knows which parser to use.